### PR TITLE
Add sales funnel blueprint for Hackbox Mini MCP Node Edition

### DIFF
--- a/content/hackbox_mini_sales_funnel.md
+++ b/content/hackbox_mini_sales_funnel.md
@@ -1,0 +1,90 @@
+---
+title: "Hackbox Mini - MCP Node Edition Sales Funnel"
+description: "Optimized funnel strategy guiding prospects from awareness to retention."
+---
+
+## Product
+Hackbox Mini - MCP Node Edition
+
+## Target Audience
+Security researchers, penetration testers, and advanced hardware hobbyists who need a portable, multi-protocol embedded node for rapid prototyping, field testing, and cybersecurity labs.
+
+## Sales Funnel Stages
+
+### 1. Awareness
+* Tactical social media campaigns on X (Twitter), Reddit r/hardwaresecurity, and LinkedIn security groups showcasing Hackbox Mini use cases.
+* Technical blog series about hardware pentesting workflows, SEO-optimized for "embedded penetration testing toolkit" and similar keywords.
+* Podcast sponsorships and YouTube collaborations with influential hardware hackers and cybersecurity educators.
+
+*   **Content Examples:**
+    * Blog post: "From Lab to Field: Why the Hackbox Mini is Your Portable MCP Node"
+    * 30-second social ad: Close-up shots of Hackbox Mini hooking into CAN/I2C buses with overlay text "Deploy Multi-Protocol Attacks in Minutes"
+    * Podcast mid-roll script highlighting rapid deployment and open-source tooling compatibility
+
+### 2. Interest
+* Dedicated landing page with interactive 3D product viewer, hero headline "Own the Portable MCP Node Built for Offensive Security," and concise explainer copy.
+* Embedded demo video walking through a live firmware extraction workflow.
+* Highlighted testimonials from known hardware security professionals and university lab directors.
+
+*   **Landing Page Key Elements:**
+    * Bold hero section with CTA button "Explore Hackbox Mini"
+    * Animated feature grid (MCP node capabilities, modular add-ons, open-source toolchain support)
+    * Sticky mini-CTA linking to spec sheet download
+    * Social proof carousel with logos of partner labs and conferences
+
+### 3. Consideration
+* Interactive comparison chart versus competing portable hacking kits (price, supported protocols, community support).
+* Resource hub gated by email: firmware extraction checklist, Hackbox Mini CLI quick-start guide, and virtual workshop registration.
+* Live chat staffed by technical specialists plus calendar integration for scheduling demos.
+
+*   **Free Resource Examples:**
+    * Downloadable "Hackbox Mini Protocol Support Matrix" PDF
+    * Sample Python scripts for automating MCP Node operations
+    * Invite-only Discord server with monthly office hours and lab challenges
+
+### 4. Decision
+* Time-boxed launch bundle: free protocol adapter pack + 10% discount when purchased within 14 days of signup.
+* Transparent pricing tiers (base kit, pro kit with accessories) and 30-day money-back guarantee.
+* Trust badges (secure checkout, warranty coverage) and countdown timer synced to promotional calendar.
+
+*   **Call to Action Examples:**
+    * "Buy Now & Secure the Launch Bundle"
+    * "Deploy Your Hackbox Mini Today"
+    * "Claim Your Field Kit Upgrade"
+
+### 5. Action (Purchase)
+* Single-page checkout with auto-filled contact details from CRM, express payment options (Apple Pay, Google Pay, PayPal, major credit cards), and financing via Affirm.
+* Upsell module suggesting compatible probes and carrying case.
+* Order summary with estimated delivery window and support contact.
+
+*   **Checkout Page Optimization:**
+    * Minimize fields to email, shipping, payment; allow guest checkout
+    * Progress indicator and trust badges above the fold
+    * Inline validation and error messaging to reduce friction
+
+### 6. Retention
+* Automated onboarding email sequence delivering setup videos, best practices, and community invites.
+* Quarterly customer-only virtual labs demonstrating advanced attack scenarios.
+* Loyalty program awarding points for referrals, shared case studies, and repeat purchases.
+
+*   **Post-Purchase Email Sequence:**
+    * Day 0: Thank-you email with order confirmation, setup guide, and Discord invite
+    * Day 3: "First Hack" tutorial video + troubleshooting tips
+    * Day 10: Request for product review and case study submission form
+    * Day 30: Offer on accessories + invitation to live lab session
+
+## Key Performance Indicators (KPIs)
+* Cost per lead (awareness -> interest)
+* Landing page conversion rate (visitor -> resource download)
+* Demo booking rate and sales-qualified lead conversion
+* Checkout completion rate and average order value
+* Repeat purchase rate within 6 months
+* Net promoter score (post-purchase satisfaction)
+
+## Tools and Technologies
+* Web platform: Shopify Plus with custom Liquid sections + headless front-end via Next.js
+* Analytics: Google Analytics 4, Hotjar heatmaps, and server-side event tracking with Segment
+* CRM & marketing automation: HubSpot for lead nurturing, workflows, and sales pipeline
+* Email & transactional messaging: Klaviyo integrated with Shopify for dynamic segments
+* Support & community: Intercom for live chat, Discord for community engagement, and Calendly for demo scheduling
+* A/B testing: Optimizely for landing page experiments and Rebuy for personalized upsells


### PR DESCRIPTION
## Summary
- add a dedicated sales funnel strategy for the Hackbox Mini MCP Node Edition
- document tactics and content ideas for each funnel stage from awareness through retention
- outline supporting KPIs and tooling recommendations to monitor and optimize performance

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_6901785f91e883329ba43844786e5da9